### PR TITLE
Add JSON body to bookmark POST requests in .http file

### DIFF
--- a/BackendSolution/WebService/WebService.http
+++ b/BackendSolution/WebService/WebService.http
@@ -182,12 +182,27 @@ Accept: application/json
 
 ### Add bookmark (POST)
 POST {{WebService_HostAddress}}/api/bookmark?userId=1
+Content-Type: application/json
+
+{
+  "pageId": 1
+}
 
 ### Add second bookmark
 POST {{WebService_HostAddress}}/api/bookmark?userId=1
+Content-Type: application/json
+
+{
+  "pageId": 1
+}
 
 ### Add duplicate bookmark (should return 409 Conflict)
 POST {{WebService_HostAddress}}/api/bookmark?userId=1
+Content-Type: application/json
+
+{
+  "pageId": 1
+}
 
 ### Add bookmark for non-existent user (should return 404)
 POST {{WebService_HostAddress}}/api/bookmark?userId=99999


### PR DESCRIPTION
Updated the WebService.http file to include Content-Type headers and JSON bodies for bookmark POST requests. Seems like they might have been forgotten?